### PR TITLE
Fix integration with show-matches, and add documentation

### DIFF
--- a/fzy.1
+++ b/fzy.1
@@ -45,6 +45,18 @@ Non-interactive mode. Print the matches in sorted order for QUERY to stdout.
 Read input delimited by ASCII NUL characters.
 .
 .TP
+.BR \-d ", " \-\-delimiter =\fIDELIM\fR
+Use DELIM to split the line to fields (default ':')
+.
+.TP
+.BR \-f ", " \-\-field =\fINUM\fR
+Use field NUM for search (default is the whole line)
+.
+.TP
+.BR \-F ", " \-\-output\-field =\fINUM\fR
+Use field NUM for output (default is the whole line)
+.
+.TP
 .BR \-h ", " \-\-help
 Usage help.
 .
@@ -99,5 +111,9 @@ List running processes, kill the selected process
 .TP
 .BR "git checkout $(git branch | cut -c 3- | fzy)"
 Same as above, but switching git branches.
+.TP
+.BR "cat /etc/passwd | fzy -d: -f1 -F6"
+Fuzzy-search the first field delimited by ':' and then print the sixth field.
+In this case, searching by username, and then outputting their home directory
 .SH AUTHOR
 John Hawthorn <john.hawthorn@gmail.com>

--- a/src/fzy.c
+++ b/src/fzy.c
@@ -36,7 +36,7 @@ int main(int argc, char *argv[]) {
 		for (size_t i = 0; i < choices_available(&choices); i++) {
 			if (options.show_scores)
 				printf("%f\t", choices_getscore(&choices, i));
-			printf("%s\n", choices_get(&choices, i));
+			printf("%s\n", choices_get_result(&choices, i));
 		}
 	} else {
 		/* interactive */


### PR DESCRIPTION
This fixes a bug where `-e/--show-matches` does not work with the new `-F/--output-field` flag.

I also added some basic documentation to the man page. This includes a verbatim copy of what is already provided by `--help`, as well as the passwd example from https://github.com/jhawthorn/fzy/pull/185.

For the sake of keeping a simple diff, this PR does not account for the merge conflict with `master`. The conflict is extremely minor.